### PR TITLE
Fixed BasicTransport bug with extra bytes in messages (19cb5ad )

### DIFF
--- a/src/BasicTransport.h
+++ b/src/BasicTransport.h
@@ -403,12 +403,16 @@ class BasicTransport : public Transport {
      */
     struct AllDataHeader {
         CommonHeader common;         // Common header fields.
+        uint16_t messageLength;      // Total # bytes in the message (i.e.,
+                                     // the bytes following this header).
 
         // The remaining packet bytes after the header constitute the
         // entire request or response message.
 
-        explicit AllDataHeader(RpcId rpcId, uint8_t flags)
-            : common(PacketOpcode::ALL_DATA, rpcId, flags) {}
+        explicit AllDataHeader(RpcId rpcId, uint8_t flags,
+                uint16_t messageLength)
+            : common(PacketOpcode::ALL_DATA, rpcId, flags)
+            , messageLength(messageLength) {}
     } __attribute__((packed));
 
     /**


### PR DESCRIPTION
BasicTransport didn't properly handle the case where drivers add
extra bytes to packets in order to meet minimum-packet-length
requirements of networks; the result was extraneous bytes at the
ends of some messages.
