### PR TITLE
Fixed null-pointer dereference in BasicTransport.

### DIFF
--- a/src/BasicTransport.cc
+++ b/src/BasicTransport.cc
@@ -717,6 +717,7 @@ BasicTransport::IncomingPacketHandler::handlePacket(Driver::Received* received)
                         header->offset, header->length);
 #endif
                 if (header->common.flags & RESTART) {
+                    clientRpc->response->reset();
                     clientRpc->transmitOffset = 0;
                     clientRpc->grantOffset = 0;
                     clientRpc->resendLimit = 0;

--- a/src/BasicTransportTest.cc
+++ b/src/BasicTransportTest.cc
@@ -578,6 +578,8 @@ TEST_F(BasicTransportTest, handlePacket_resendFromServer_restart) {
             driver->outputLog);
     driver->outputLog.clear();
     EXPECT_EQ(10lu, transport.outgoingRpcs[1]->transmitOffset);
+    transport.outgoingRpcs[1]->response->appendCopy("abcde", 5);
+    EXPECT_EQ(5lu, transport.outgoingRpcs[1]->response->size());
 
     driver->receivePacket("mock:server=1", BasicTransport::ResendHeader(
             BasicTransport::RpcId(666, 1), 0, 5,
@@ -586,6 +588,7 @@ TEST_F(BasicTransportTest, handlePacket_resendFromServer_restart) {
             "NEED_GRANT, RETRANSMISSION abcde",
             driver->outputLog);
     EXPECT_EQ(5lu, transport.outgoingRpcs[1]->transmitOffset);
+    EXPECT_EQ(0lu, transport.outgoingRpcs[1]->response->size());
 }
 TEST_F(BasicTransportTest,
         handlePacket_resendFromServer_transmitOffsetChanges) {


### PR DESCRIPTION
Possible fix for recovery master crash on recovery.py

The DIE in MessageAccumulator::requestRetransmission could trigger
if a RESTART arrived after a client already received some response
bytes. In this case, it deleted its MessageAccumulator, but didn't
clear the response buffer, which could cause a NULL accumulator
to be invoked in handleTimerEvent.
